### PR TITLE
Chore/buttons

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,5 +19,12 @@ module.exports = {
     '@typescript-eslint/no-explicit-any': 'error',
     '@typescript-eslint/func-call-spacing': 'off',
     '@typescript-eslint/no-require-imports': 'warn',
+    '@typescript-eslint/consistent-type-imports': [
+      'error',
+      {
+        prefer: 'type-imports',
+        fixStyle: 'inline-type-imports',
+      },
+    ],
   },
 };

--- a/babel.config.js
+++ b/babel.config.js
@@ -4,10 +4,9 @@ module.exports = {
     [
       'module-resolver',
       {
-        root: ['./src'],
+        root: ['.'],
         extensions: ['.js', '.jsx', '.ts', '.tsx'],
         alias: {
-          '@': './src',
           '@assets': './src/assets',
           '@features': './src/features',
           '@hooks': './src/hooks',
@@ -15,6 +14,7 @@ module.exports = {
           '@shared': './src/shared',
           '@store': './src/store',
           '@utils': './src/utils',
+          '@types': './src/types/index.ts',
           test: './test',
           underscores: 'lodash',
         },

--- a/babel.config.js
+++ b/babel.config.js
@@ -4,7 +4,7 @@ module.exports = {
     [
       'module-resolver',
       {
-        root: ['.'],
+        root: ['./src'],
         extensions: ['.js', '.jsx', '.ts', '.tsx'],
         alias: {
           '@': './src',

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,19 @@
 import React from 'react';
 import {StyleSheet, View, Text} from 'react-native';
 import SVGWrapper from './shared/components/SVGWrapper';
+import Header from './shared/components/Text/Header';
+import SubHeader from './shared/components/Text/SubHeader';
+import Caption from './shared/components/Text/Caption';
+import textCompVariant from './utils/text';
 
 function App(): React.JSX.Element {
   return (
     <View>
       <SVGWrapper name="logo" height={36} width={36} fill="red" />
       <Text>Great Shopping Experience</Text>
+      <Header />
+      <SubHeader />
+      <Caption variant={textCompVariant.captionThin} />
     </View>
   );
 }

--- a/src/shared/components/PawfectButton.tsx
+++ b/src/shared/components/PawfectButton.tsx
@@ -1,0 +1,32 @@
+import {View, TouchableOpacity, type TouchableOpacityProps} from 'react-native';
+import React, {type ReactElement, type Ref} from 'react';
+import type {ViewPropsType} from '../types';
+
+interface PawfectButtonProps extends TouchableOpacityProps {
+  children: ReactElement;
+  containerStyle?: ViewPropsType;
+  buttonStyle?: ViewPropsType;
+  disabledStyle?: ViewPropsType;
+  buttonRef?: Ref<View>;
+}
+
+export default function PawfectButton({
+  children,
+  containerStyle = {},
+  buttonStyle = {},
+  disabledStyle = {},
+  buttonRef,
+  ...props
+}: PawfectButtonProps) {
+  return (
+    <View style={containerStyle}>
+      <TouchableOpacity
+        activeOpacity={0.7}
+        ref={buttonRef}
+        style={[buttonStyle, disabledStyle]}
+        {...props}>
+        {children}
+      </TouchableOpacity>
+    </View>
+  );
+}

--- a/src/shared/components/Text/Body.tsx
+++ b/src/shared/components/Text/Body.tsx
@@ -1,0 +1,26 @@
+import {StyleProp, StyleSheet, Text, TextStyle} from 'react-native';
+import React, {JSX} from 'react';
+import textCompVariant from '@utils/text';
+import {headerStyle} from '../styles';
+import {TextComponentVariants} from '@shared/types';
+
+/***
+ * Body component for content body
+ *
+ * @param {props} - variant can be only one the following- BodyLarge, bodyMedium, bodySmall, bodyThin
+ * @returns {React JSX.Element}
+ *
+ */
+
+interface BodyProps {
+  variant?: TextComponentVariants;
+  textStyle?: TextStyle;
+}
+
+export default function Body({
+  variant = textCompVariant.BodyLarge,
+  textStyle = {},
+}: BodyProps): JSX.Element {
+  const style = headerStyle('dark');
+  return <Text style={StyleSheet.compose(variant, textStyle)}>Header</Text>;
+}

--- a/src/shared/components/Text/Caption.tsx
+++ b/src/shared/components/Text/Caption.tsx
@@ -1,0 +1,26 @@
+import {StyleSheet, Text, TextStyle} from 'react-native';
+import React, {JSX} from 'react';
+import textCompVariant from '@utils/text';
+import {headerStyle} from '../styles';
+import {TextComponentVariants} from '@shared/types';
+
+/***
+ * Caption component for content captions
+ *
+ * @param {props} - variant can be only one the following- captionLarge, captionMedium, captionSmall, captionThin
+ * @returns {React JSX.Element}
+ *
+ */
+
+interface CaptionProps {
+  variant?: TextComponentVariants;
+  textStyle?: TextStyle;
+}
+
+export default function Caption({
+  variant = textCompVariant.captionLarge,
+  textStyle = {},
+}: CaptionProps): JSX.Element {
+  const style = headerStyle('dark');
+  return <Text style={StyleSheet.compose(variant, textStyle)}>Caption</Text>;
+}

--- a/src/shared/components/Text/Header.tsx
+++ b/src/shared/components/Text/Header.tsx
@@ -1,0 +1,25 @@
+import {StyleProp, StyleSheet, Text, TextStyle} from 'react-native';
+import React, {JSX} from 'react';
+import textCompVariant from '@utils/text';
+import {headerStyle} from '../styles';
+
+/***
+ * Header component for content header
+ *
+ * @param {props} - variant can be only one the following- headerLarge, headerMedium, headerSmall, headerThin
+ * @returns {React JSX.Element}
+ *
+ */
+
+interface HeaderProps {
+  variant?: StyleProp<TextStyle>;
+  textStyle?: TextStyle;
+}
+
+export default function Header({
+  variant = textCompVariant.headerLarge,
+  textStyle = {},
+}: HeaderProps): JSX.Element {
+  const style = headerStyle('dark');
+  return <Text style={StyleSheet.compose(variant, textStyle)}>Header</Text>;
+}

--- a/src/shared/components/Text/SubHeader.tsx
+++ b/src/shared/components/Text/SubHeader.tsx
@@ -1,0 +1,25 @@
+import {StyleProp, StyleSheet, Text, TextStyle} from 'react-native';
+import React, {JSX} from 'react';
+import textCompVariant from '@utils/text';
+import {headerStyle} from '../styles';
+
+/***
+ * Sub header component for content sub header
+ *
+ * @param {props} - variant can be only one the following- subheaderLarge, subheaderMedium, subheaderSmall, subheaderThin
+ * @returns {React JSX.Element}
+ *
+ */
+
+interface SubHeaderProps {
+  variant?: StyleProp<TextStyle>;
+  textStyle?: TextStyle;
+}
+
+export default function SubHeader({
+  variant = textCompVariant.subheaderLarge,
+  textStyle = {},
+}: SubHeaderProps): JSX.Element {
+  const style = headerStyle('dark');
+  return <Text style={StyleSheet.compose(variant, textStyle)}>Header</Text>;
+}

--- a/src/shared/components/styles.ts
+++ b/src/shared/components/styles.ts
@@ -1,0 +1,6 @@
+import {StyleSheet} from 'react-native';
+
+export const headerStyle = themeMode =>
+  StyleSheet.create({
+    textStyle: {},
+  });

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,0 +1,16 @@
+type FontWeightStyle = {
+  fontWeight: string; // Or more specific type like 'bold' | 'normal' | '600' if known
+};
+
+type TextVariantCategory = 'header' | 'subheader' | 'body' | 'caption';
+type TextVariantSize = 'Large' | 'Medium' | 'Small' | 'Thin';
+
+type TextVariantKey = `${TextVariantCategory}${TextVariantSize}`;
+
+type TextVariantStyle = FontWeightStyle & {
+  fontSize: number;
+};
+
+export type TextComponentVariants = {
+  [key in TextVariantKey]: TextVariantStyle;
+};

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -1,3 +1,5 @@
+import {type StyleProp, type TextStyle, type ViewStyle} from 'react-native';
+
 type FontWeightStyle = {
   fontWeight: string; // Or more specific type like 'bold' | 'normal' | '600' if known
 };
@@ -14,3 +16,6 @@ type TextVariantStyle = FontWeightStyle & {
 export type TextComponentVariants = {
   [key in TextVariantKey]: TextVariantStyle;
 };
+
+export type ViewPropsType = StyleProp<ViewStyle>;
+export type TextPropsType = StyleProp<TextStyle>;

--- a/src/utils/text.tsx
+++ b/src/utils/text.tsx
@@ -1,46 +1,39 @@
+import {TextComponentVariants} from '../shared/types';
 import Fonts from './fonts';
 
-const textCompVariant = {
+const textCompVariant: TextComponentVariants = {
   headerLarge: {
     fontSize: 36,
     ...Fonts.bold,
-    lineHeight: '100%',
   },
   headerMedium: {
     fontSize: 16,
     ...Fonts.bold,
-    lineHeight: '100%',
   },
   headerSmall: {
     fontSize: 20,
     ...Fonts.bold,
-    lineHeight: '100%',
   },
   headerThin: {
     fontSize: 14,
     ...Fonts.bold,
-    lineHeight: '100%',
   },
 
   subheaderLarge: {
     fontSize: 16,
     ...Fonts.semiBold,
-    lineHeight: '100%',
   },
   subheaderMedium: {
     fontSize: 14,
     ...Fonts.semiBold,
-    lineHeight: '100%',
   },
   subheaderSmall: {
     fontSize: 12,
     ...Fonts.semiBold,
-    lineHeight: '100%',
   },
   subheaderThin: {
     fontSize: 10,
     ...Fonts.semiBold,
-    lineHeight: '100%',
   },
 
   bodyLarge: {
@@ -59,19 +52,19 @@ const textCompVariant = {
     fontSize: 10,
     ...Fonts.medium,
   },
-  descriptionLarge: {
+  captionLarge: {
     fontSize: 16,
     ...Fonts.medium,
   },
-  descriptionMedium: {
+  captionMedium: {
     fontSize: 14,
     ...Fonts.regular,
   },
-  descriptionSmall: {
+  captionSmall: {
     fontSize: 12,
     ...Fonts.regular,
   },
-  descriptionThin: {
+  captionThin: {
     fontSize: 10,
     ...Fonts.regular,
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,17 +5,18 @@
     "strict": true,
     "moduleResolution": "bundler",
     "types": ["react-native", "react", "node"],
-    "baseUrl": "./src",
+    "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"],
       "@assets/*": ["./src/assets/*"],
       "@hooks/*": ["./src/hooks/*"],
       "@navigator/*": ["./src/navigator/*"],
       "@shared/*": ["./src/shared/*"],
       "@features/*": ["./src/features/*"],
       "@store/*": ["./src/store/*"],
-      "@utils/*": ["./src/utils/*"]
-    }
+      "@utils/*": ["./src/utils/*"],
+      "@types": ["./src/shared/types/index.ts"]
+    },
+    "isolatedModules": true
   },
   "include": [
     "src/**/*.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "strict": true,
     "moduleResolution": "bundler",
     "types": ["react-native", "react", "node"],
-    "baseUrl": ".",
+    "baseUrl": "./src",
     "paths": {
       "@/*": ["./src/*"],
       "@assets/*": ["./src/assets/*"],


### PR DESCRIPTION
feat: Introduce the Pawfect Button Component - A Versatile Button Wrapper

This pull request introduces the PawfectButton component, a foundational and highly reusable button component designed to streamline button implementation throughout the application.

Purpose:

The PawfectButton serves as a wrapper around other button implementations (primarily TouchableOpacity in React Native). Its goal is to provide a consistent and extensible base for all button elements within the Pawfect app, promoting code reuse and simplifying styling.

Key Features:

Wrapper Component: Acts as a direct replacement for TouchableOpacity, inheriting its core functionality and behavior.
Prop Extension: The PawfectButton component's type definitions extend the existing TouchableOpacity props. This means it accepts all the standard props that you would normally pass to a TouchableOpacity component (e.g., onPress, disabled, activeOpacity).
Style Flexibility: Accepts standard style props, allowing for easy customization of the button's appearance.
Centralized Button Logic (Future Potential): While currently a direct wrapper, this component provides a central point for potentially adding common button-related logic or styling defaults in the future, ensuring consistency across all buttons in the app.
Benefits:

Increased Code Reusability: By using PawfectButton as the base for all buttons, we reduce code duplication and promote a more DRY (Don't Repeat Yourself) codebase.
Improved Consistency: Ensures a uniform base behavior and styling structure for all button elements across different features of the application.
Simplified Development: Developers can leverage the PawfectButton with the familiarity of TouchableOpacity props, simplifying button implementation.
Enhanced Maintainability: Future modifications or enhancements to button behavior or styling can be applied centrally within the PawfectButton component, making maintenance easier.
Laying the Groundwork for Theming: This component can be a key element in implementing a consistent design system and theming capabilities for buttons in the future.
Usage:

The PawfectButton can be used as a direct replacement for TouchableOpacity:

import { PawfectButton } from '@components/common/PawfectButton'; // Assuming its location

const MyScreen = () => {
  const handlePress = () => {
    console.log('Button pressed!');
  };

  return (
    <PawfectButton onPress={handlePress} style={styles.myButtonStyle} activeOpacity={0.8}>
    <Text>Press me</Text>
    </PawfectButton>
  );
};